### PR TITLE
Feat : 토큰 재발행 API 구현, 닉네임 중복 확인 API 구현, 2개의 메일 전송 API 구현

### DIFF
--- a/ggum/src/main/java/com/example/ggum/domain/user/repository/UserRepository.java
+++ b/ggum/src/main/java/com/example/ggum/domain/user/repository/UserRepository.java
@@ -9,6 +9,7 @@ import com.example.ggum.domain.user.entity.User;
 public interface UserRepository extends JpaRepository<User,String> {
     User findByEmail(String email);
     Boolean existsByEmail(String email);
+    Boolean existsByUsername(String Username);
     User findByEmailAndPassword(String email, String password);
     User findById(Long id);
 }

--- a/ggum/src/main/java/com/example/ggum/domain/user/service/UserService.java
+++ b/ggum/src/main/java/com/example/ggum/domain/user/service/UserService.java
@@ -50,4 +50,32 @@ public class UserService {
         }
         return null;
     }
+
+    // 학교 웹메일인지 확인하는 파싱 알고리즘
+    public boolean isSchoolEmail(String email) {
+        boolean result = false;
+        String[] parts = email.split("@");
+        if (parts.length != 2) {// 이메일 형식인지 확인
+            result = false;
+        }
+        else {//학교 웹 메일인지 확인
+            String domain = parts[1];
+            String[] domainParts = domain.split("\\.");
+            int length = domainParts.length;
+            if (length >= 3 && "ac".equals(domainParts[length - 2]) && "kr".equals(domainParts[length - 1])) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    // 이메일 중복 확인 메서드
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    // 닉네임 중복 확인 메서드
+    public boolean existsByUsername(String Username) {
+        return userRepository.existsByUsername(Username);
+    }
 }

--- a/ggum/src/main/java/com/example/ggum/security/TokenProvider.java
+++ b/ggum/src/main/java/com/example/ggum/security/TokenProvider.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.stereotype.Service;
 
 import com.example.ggum.domain.user.entity.User;
@@ -38,5 +39,19 @@ public class TokenProvider {
                 .getBody();
         return claims.getSubject();
     }
+
+    public Claims validateAndGetClaims(String token) {
+        try {
+            // 토큰이 유효할 경우 Claims 반환
+            return Jwts.parser()
+                    .setSigningKey(SECRET_KEY)
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료된 경우에도 Claims 반환 가능
+            return e.getClaims();
+        }
+    }
+
 }
 


### PR DESCRIPTION
Feat : 토큰 재발행 API 구현, 닉네임 중복 확인 API 구현, 2개의 메일 전송 API 구현

### 관련 이슈

- 

### 요약 📝

-  4개의 API 새로운 구현, 1개의 API 제거

### 상세 내용 🔑

- 기존의 sendMail을 없애고, mailSendForSignup와 mailSendForCheckEmail로 메일 인증 API를 만들었습니다. 또 닉네임 중복 확인 API와 토큰 재발행 API도 구현했습니다.

### 유의사항 또는 기타 👨‍💻

- 현재 닉네임 수정 API가 auth에 있습니다. 조만간 mypage에 욺길 예정입니다.
